### PR TITLE
[BUGFIX] Use console core:archive in cron job

### DIFF
--- a/assets/piwik-archive
+++ b/assets/piwik-archive
@@ -1,1 +1,1 @@
-6 * * * * www-data /usr/local/bin/php /var/www/html/misc/cron/archive.php
+6 * * * * www-data /usr/local/bin/php /var/www/html/console core:archive


### PR DESCRIPTION
Use `console core:archive` instead of the deprecated `archive.php`
script.

```
-------------------------------------------------------
Using this 'archive.php' script is no longer recommended.
Please use '/path/to/php /var/www/html/console core:archive ' instead.
To get help use '/path/to/php /var/www/html/console core:archive --help'
See also: http://piwik.org/docs/setup-auto-archiving/

If you cannot use the console because it requires CLI
try 'php archive.php --url=http://your.piwik/path'
-------------------------------------------------------
```

Resolves #11