### PR TITLE
[BUGFIX] Fix permissions for config files after substitution

### DIFF
--- a/assets/entrypoint.sh
+++ b/assets/entrypoint.sh
@@ -27,6 +27,7 @@ do
 	/bin/sed -i "s@{{ DB_NAME }}@${DB_ENV_MYSQL_DATABASE}@" ${SETTINGS_PATH}
 	/bin/sed -i "s@{{ DB_USER }}@${DB_ENV_MYSQL_USER}@" ${SETTINGS_PATH}
 	/bin/sed -i "s@{{ DB_PASSWORD }}@${DB_ENV_MYSQL_PASSWORD}@" ${SETTINGS_PATH}
+	/bin/chown www-data:www-data ${SETTINGS_PATH}
 done
 
 


### PR DESCRIPTION
Error message:
```
An error occurred
Die Piwik-Konfigurationsdatei (config/config.ini.php) ist nicht schreibbar, Ihre Änderungen werden nicht gespeichert. Bitte ändern Sie die Zugriffsrechte der Konfigurationsdatei, um diese schreibbar zu machen.
```