### PR TITLE
db-hostname

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,11 @@
+# Sinso Piwik
+
+## Configurations
+### Environment variables
+- DB_ENV_MYSQL_HOST: MySql host (default is db)
+- DB_ENV_MYSQL_DATABASE: MySql database name
+- DB_ENV_MYSQL_USER: MySql database user
+- DB_ENV_MYSQL_PASSWORD: MySql password
+- SSMTP_ROOT: The person who gets all mail for userids < 1000
+- SSMTP_MAILHUB: The place where the mail goes
+- SSMTP_HOSTNAME: The full hostname

--- a/assets/entrypoint.sh
+++ b/assets/entrypoint.sh
@@ -17,12 +17,13 @@ cp /opt/docker/ssmtp.conf ${SSMTP_SETTINGS_PATH}
 #
 # CONFIGURE
 #
+MYSQL_DB_HOST=${DB_ENV_MYSQL_HOST:-db}
 
 find ${DOCUMENT_ROOT} -type f -name "*.docker" | while read F
 do
 	SETTINGS_PATH=`echo "${F}" | sed "s/\.docker$//"`
 	cp ${F} ${SETTINGS_PATH}
-	/bin/sed -i "s@{{ DB_HOST }}@db@" ${SETTINGS_PATH}
+	/bin/sed -i "s@{{ DB_HOST }}@${MYSQL_DB_HOST}@" ${SETTINGS_PATH}
 	/bin/sed -i "s@{{ DB_PORT }}@${DB_PORT_3306_TCP_PORT}@" ${SETTINGS_PATH}
 	/bin/sed -i "s@{{ DB_NAME }}@${DB_ENV_MYSQL_DATABASE}@" ${SETTINGS_PATH}
 	/bin/sed -i "s@{{ DB_USER }}@${DB_ENV_MYSQL_USER}@" ${SETTINGS_PATH}


### PR DESCRIPTION
Add basic README.md
Allow to override the default hostname (db) with DB_ENV_MYSQL_HOST env variable